### PR TITLE
fix: preload.ts sendSendMsgResult 安全问题

### DIFF
--- a/src/common/channels.ts
+++ b/src/common/channels.ts
@@ -1,4 +1,5 @@
 export const CHANNEL_SEND_MSG = "llonebot_send_msg"
+export const CHANNEL_SEND_BACK_MSG = "llonebot_send_back_msg"
 export const CHANNEL_RECALL_MSG = "llonebot_recall_msg"
 export const CHANNEL_GET_CONFIG = "llonebot_get_config"
 export const CHANNEL_SET_CONFIG = "llonebot_set_config"

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -136,7 +136,6 @@ export interface PostDataSendMsg {
     user_id: string,
     group_id: string,
     message?: OB11MessageData[];
-    ipc_uuid?: string
 }
 
 export interface Config {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -8,6 +8,7 @@ import {
     SelfInfo,
     User
 } from "./common/types";
+import { SendIPCMsgSession } from "./main/ipcsend";
 
 
 import {OB11Return, OB11MessageData, OB11SendMsgReturn} from "./onebot11/types";
@@ -36,7 +37,7 @@ declare var LLAPI: {
 
 declare var llonebot: {
     postData: (data: any) => void
-    listenSendMessage: (handle: (msg: PostDataSendMsg) => void) => void
+    listenSendMessage: (handle: (msg: SendIPCMsgSession<PostDataSendMsg>) => void) => void
     listenRecallMessage: (handle: (msg: {message_id: string}) => void) => void
     updateGroups: (groups: Group[]) => void
     updateFriends: (friends: User[]) => void

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -14,11 +14,15 @@ import {
     CHANNEL_UPDATE_FRIENDS,
     CHANNEL_UPDATE_GROUPS,
     CHANNEL_DELETE_FILE,
-    CHANNEL_GET_RUNNING_STATUS, CHANNEL_FILE2BASE64, CHANNEL_GET_HISTORY_MSG
+    CHANNEL_GET_RUNNING_STATUS,
+    CHANNEL_FILE2BASE64,
+    CHANNEL_GET_HISTORY_MSG,
+    CHANNEL_SEND_BACK_MSG,
 } from "./common/channels";
 
 
 import {OB11Return, OB11SendMsgReturn} from "./onebot11/types";
+import { SendIPCMsgSession } from "./main/ipcsend";
 
 
 const {contextBridge} = require("electron");
@@ -37,11 +41,14 @@ contextBridge.exposeInMainWorld("llonebot", {
         ipcRenderer.send(CHANNEL_UPDATE_FRIENDS, friends);
     },
     sendSendMsgResult: (sessionId: string, msgResult: OB11SendMsgReturn)=>{
-        ipcRenderer.send(sessionId, msgResult);
+        ipcRenderer.send(CHANNEL_SEND_BACK_MSG, {
+            id: sessionId, 
+            data: msgResult,
+        });
     },
-    listenSendMessage: (handle: (jsonData: PostDataSendMsg) => void) => {
+    listenSendMessage: (handle: (jsonData: SendIPCMsgSession<PostDataSendMsg>) => void) => {
         ipcRenderer.send(CHANNEL_LOG, "发送消息API已注册");
-        ipcRenderer.on(CHANNEL_SEND_MSG, (event: any, args: PostDataSendMsg) => {
+        ipcRenderer.on(CHANNEL_SEND_MSG, (event: any, args: SendIPCMsgSession<PostDataSendMsg>) => {
             handle(args)
         })
     },


### PR DESCRIPTION
修复 #27 
另外，删除了 `src\common\types.ts` 中的 `PostDataSendMsg.ipc_uuid`，因为不再需要这个属性了