### PR TITLE
放宽 WebSocket 连接方式中的 `echo` 参数的变量类型

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -194,3 +194,7 @@ export async function encodeSilk(filePath: string) {
         return {};
     }
 }
+
+export function isNull(value: any) {
+    return value === undefined || value === null;
+}

--- a/src/onebot11/action/BaseAction.ts
+++ b/src/onebot11/action/BaseAction.ts
@@ -23,7 +23,7 @@ class BaseAction<PayloadType, ReturnDataType> {
         }
     }
 
-    public async websocketHandle(payload: PayloadType, echo: string): Promise<OB11Return<ReturnDataType | null>> {
+    public async websocketHandle(payload: PayloadType, echo: any): Promise<OB11Return<ReturnDataType | null>> {
         const result = await this.check(payload)
         if (!result.valid) {
             return OB11Response.error(result.message, 1400)

--- a/src/onebot11/action/utils.ts
+++ b/src/onebot11/action/utils.ts
@@ -1,4 +1,5 @@
 import {OB11Return} from '../types';
+import {isNull} from '../../common/utils';
 
 export class OB11Response {
     static res<T>(data: T, status: string, retcode: number, message: string = ""): OB11Return<T> {
@@ -8,21 +9,21 @@ export class OB11Response {
             data: data,
             message: message,
             wording: message,
-            echo: ""
+            echo: null
         }
     }
 
-    static ok<T>(data: T, echo: string = "") {
+    static ok<T>(data: T, echo: any = null) {
         let res = OB11Response.res<T>(data, "ok", 0)
-        if (echo) {
+        if (!isNull(echo)) {
             res.echo = echo;
         }
         return res;
     }
 
-    static error(err: string, retcode: number, echo: string = "") {
+    static error(err: string, retcode: number, echo: any = null) {
         let res = OB11Response.res(null, "failed", retcode, err)
-        if (echo) {
+        if (!isNull(echo)) {
             res.echo = echo;
         }
         return res;

--- a/src/onebot11/server/ws/ReverseWebsocket.ts
+++ b/src/onebot11/server/ws/ReverseWebsocket.ts
@@ -33,8 +33,8 @@ export class ReverseWebsocket {
     }
 
     public async onmessage(msg: string) {
-        let receiveData: { action: ActionName, params: any, echo?: string } = {action: null, params: {}}
-        let echo = ""
+        let receiveData: { action: ActionName, params: any, echo?: any } = {action: null, params: {}}
+        let echo = null
         try {
             receiveData = JSON.parse(msg.toString())
             echo = receiveData.echo

--- a/src/onebot11/server/ws/WebsocketServer.ts
+++ b/src/onebot11/server/ws/WebsocketServer.ts
@@ -18,7 +18,7 @@ class OB11WebsocketServer extends WebsocketServerBase {
         wsClient.send(JSON.stringify(OB11Response.res(null, "failed", 1403, "token验证失败")))
     }
 
-    async handleAction(wsClient: WebSocket, actionName: string, params: any, echo?: string) {
+    async handleAction(wsClient: WebSocket, actionName: string, params: any, echo?: any) {
         const action: BaseAction<any, any> = actionMap.get(actionName);
         if (!action) {
             return wsReply(wsClient, OB11Response.error("不支持的api " + actionName, 1404, echo))
@@ -34,8 +34,8 @@ class OB11WebsocketServer extends WebsocketServerBase {
     onConnect(wsClient: WebSocket, url: string, req: IncomingMessage) {
         if (url == "/api" || url == "/api/" || url == "/") {
             wsClient.on("message", async (msg) => {
-                let receiveData: { action: ActionName, params: any, echo?: string } = {action: null, params: {}}
-                let echo = ""
+                let receiveData: { action: ActionName, params: any, echo?: any } = {action: null, params: {}}
+                let echo = null
                 try {
                     receiveData = JSON.parse(msg.toString())
                     echo = receiveData.echo

--- a/src/onebot11/server/ws/reply.ts
+++ b/src/onebot11/server/ws/reply.ts
@@ -1,13 +1,13 @@
 import * as websocket from "ws";
 import {OB11Response} from "../../action/utils";
 import {PostEventType} from "../postevent";
-import {log} from "../../../common/utils";
+import {isNull, log} from "../../../common/utils";
 
 export function wsReply(wsClient: websocket.WebSocket, data: OB11Response | PostEventType) {
     try {
         let packet = Object.assign({
         }, data);
-        if (!packet["echo"]){
+        if (isNull(packet["echo"])){
             delete packet["echo"];
         }
         wsClient.send(JSON.stringify(packet))

--- a/src/onebot11/types.ts
+++ b/src/onebot11/types.ts
@@ -77,7 +77,7 @@ export interface OB11Return<DataType> {
     retcode: number
     data: DataType
     message: string,
-    echo?: string, // ws调用api才有此字段
+    echo?: any, // ws调用api才有此字段
     wording?: string,  // go-cqhttp字段，错误信息
 }
 


### PR DESCRIPTION
某些框架（例如 [Overflow](https://github.com/MrXiaoM/Overflow)）传入的 `echo` 值并不是 `string` 类型的，并且由于 JavaScript 特有的类型转换，使得如果客户端传来 `echo` 的值为 `0` 的话会直接被替换成默认的空字符，本 PR 尝试修复了这一点。