### PR TITLE
修正 `get_version_info` 中的 `app_version` 格式

### DIFF
--- a/src/common/data.ts
+++ b/src/common/data.ts
@@ -87,4 +87,4 @@ export function getUidByUin(uin: string) {
     }
 }
 
-export const version = "v3.6.0"
+export const version = "3.6.0"


### PR DESCRIPTION
根据 [OneBot v11 文档](https://github.com/botuniverse/onebot-11/blob/master/api/public.md#get_version_info-%E8%8E%B7%E5%8F%96%E7%89%88%E6%9C%AC%E4%BF%A1%E6%81%AF)，版本号前面不需要加 `v`