### PR TITLE
更改 `message.real_id` 的参数类型优先为整数

### DIFF
--- a/src/onebot11/constructor.ts
+++ b/src/onebot11/constructor.ts
@@ -34,7 +34,7 @@ export class OB11Constructor {
             user_id: parseInt(msg.senderUin),
             time: parseInt(msg.msgTime) || 0,
             message_id: msg.msgShortId,
-            real_id: msg.msgId,
+            real_id: parseInt(msg.msgId) || msg.msgId,
             message_type: msg.chatType == ChatType.group ? "group" : "private",
             sender: {
                 user_id: parseInt(msg.senderUin),

--- a/src/onebot11/types.ts
+++ b/src/onebot11/types.ts
@@ -59,7 +59,7 @@ export interface OB11Message {
     self_id?: number,
     time: number,
     message_id: number,
-    real_id: string,
+    real_id: number | string,
     user_id: number,
     group_id?: number,
     message_type: "private" | "group",


### PR DESCRIPTION
避免在某些框架上因类型不对导致出错